### PR TITLE
Add elife-xpub public data

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,38 @@
 # builder-configuration
 Contains non-sensitive Salt formulas configuration
+
+
+## Naming convention
+
+Pillar files applied to projects must be named:
+
+```
+pillar/my-project-public.sls
+```
+
+mimicking the `pillar/my-project.sls` file found in `builder-private`.
+
+Once added, these files must be composed into [top.sls](https://github.com/elifesciences/builder-private/blob/master/pillar/top.sls) to be used.
+
+## Pillar values
+
+Commented-out values such as
+
+```
+my_project:
+    database:
+        # user: 
+        # password: 
+```
+
+are sensitive, and are configured in [builder-private](https://github.com/elifesciences/builder-private/tree/master/pillar) instead.
+
+Values clearly fake, tagged like
+
+```
+my_project:
+    orcid:
+        client_id: fake_client_id # overwritten by environment
+```
+
+will be overridden by `builder-private` for certain environments (like `prod`) with real values.

--- a/pillar/elife-xpub-public.sls
+++ b/pillar/elife-xpub-public.sls
@@ -1,0 +1,26 @@
+elife_xpub:
+    api:
+        endpoint: https://ci--xpub.elifesciences.org
+    database:
+        # user: 
+        # password: 
+        email: it-admin@elifesciences.org
+        collection: xpub
+    ink:
+        # user: 
+        # password: 
+        endpoint: http://54.157.211.94:3000
+    orcid:
+        client_id: fake_client_id # overwritten by environment
+        client_secret: fake_client_secret # overwritten by environment
+    pubsweet:
+        base_url: https://ci--xpub.elifesciences.org
+    s3:
+        bucket: ci-elife-xpub # does not really exist, overwritten by environment
+
+elife:
+    aws:
+        # `elife-xpub` IAM user
+        # access_key_id:
+        # secret_access_key:
+        region: us-east-1

--- a/pillar/environment-demo-public.sls
+++ b/pillar/environment-demo-public.sls
@@ -1,0 +1,11 @@
+elife_xpub:
+    api:
+        endpoint: https://demo--xpub.elifesciences.org
+    orcid:
+        # sandbox.orcid.org credentials
+        # client_id: 
+        # client_secret:
+    pubsweet:
+        base_url: https://demo--xpub.elifesciences.org
+    s3:
+        bucket: demo-elife-xpub

--- a/pillar/environment-prod-public.sls
+++ b/pillar/environment-prod-public.sls
@@ -1,0 +1,10 @@
+elife_xpub:
+    api:
+        endpoint: https://xpub.elifesciences.org
+    orcid:
+        # client_id:
+        # client_secret:
+    pubsweet:
+        base_url: https://xpub.elifesciences.org
+    s3:
+        bucket: prod-elife-xpub


### PR DESCRIPTION
Attempt to extract all configuration that is public for ease of update. Credentials or other secrets have to stay into `builder-private`.

For https://github.com/elifesciences/issues/issues/3691 (contains too many details)