### PR TITLE
Introduce journal-public with default xpub integration

### DIFF
--- a/pillar/journal-public.sls
+++ b/pillar/journal-public.sls
@@ -1,2 +1,3 @@
 journal:
      submit_url: https://submit.elifesciences.org/
+     feature_xpub: false

--- a/pillar/journal-public.sls
+++ b/pillar/journal-public.sls
@@ -1,0 +1,2 @@
+journal:
+     submit_url: https://submit.elifesciences.org/


### PR DESCRIPTION
Will need to be included by builder-private, but creates a center of gravity for non-sensitive configuration.

Leaving `journal.feature_xpub` for later at it is environment-specific and not all environments are available here yet.

For https://github.com/elifesciences/journal-formula/pull/83