### PR TITLE
Add journal-cms pillars

### DIFF
--- a/pillar/environment-ci-public.sls
+++ b/pillar/environment-ci-public.sls
@@ -1,2 +1,10 @@
 elife:
     env: ci
+
+journal_cms:
+    {% set dummy_url = 'http://localhost:8080' %}
+    api:
+        articles_endpoint_for_migration: {{ dummy_url }}/articles/%s/versions
+        articles_endpoint: {{ dummy_url }}/articles/%s/versions
+        metrics_endpoint: {{ dummy_url }}/metrics/article/%s/%s
+        all_articles_endpoint: {{ dummy_url }}/articles

--- a/pillar/environment-continuumtest-public.sls
+++ b/pillar/environment-continuumtest-public.sls
@@ -1,6 +1,40 @@
 elife:
     env: continuumtest
 
+{% set journal_url = 'https://continuumtest--journal.elifesciences.org' %}
+{% set journal_preview_url = 'https://continuumtestpreview--journal.elifesciences.org' %}
+{% set journal_cms_url = 'https://continuumtest--journal-cms.elifesciences.org' %}
+{% set medium_url = 'http://continuumtest--medium.elife.internal' %}
+{% set search_url = 'http://continuumtest--search.elife.internal' %}
+{% set recommendations_url = 'http://continuumtest--recommendations.elife.internal' %}
+{% set gateway_url_public = 'https://continuumtest--cdn-gateway.elifesciences.org' %}
+{% set gateway_url_internal = 'http://continuumtest--gateway.elife.internal' %}
+{% set gateway_url_for_migration = 'https://prod--gateway.elifesciences.org' %}
+{% set lax_url = 'https://continuumtest--lax.elifesciences.org' %}
+{% set metrics_url = 'http://continuumtest--metrics.elife.internal' %}
+{% set profiles_url = 'http://continuumtest--profiles.elife.internal' %}
+{% set annotations_url = 'http://continuumtest--annotations.elife.internal' %}
+{% set digests_url = 'http://continuumtest--digests.elife.internal' %}
+{% set iiif_url = 'https://continuumtest--cdn-iiif.elifesciences.org' %}
+
 journal:
     feature_xpub: true
     submit_url: https://staging--xpub.elifesciences.org/login
+
+journal_cms:
+    aws:
+        queue: journal-cms--continuumtest
+        topic_template: arn:aws:sns:us-east-1:512686554592:bus-%s--continuumtest
+    journal:
+        base_uri: {{ journal_url }}
+        preview_uri: {{ journal_preview_url }}
+    iiif:
+        base_uri: "{{ iiif_url }}/journal-cms/"
+        mount: iiif
+    api:
+        gateway: {{ gateway_url_internal }}
+        articles_endpoint_for_migration: {{ gateway_url_for_migration }}/articles/%s/versions
+        articles_endpoint: {{ gateway_url_internal }}/articles/%s/versions
+        metrics_endpoint: {{ gateway_url_internal }}/metrics/article/%s/%s
+        all_articles_endpoint: {{ gateway_url_internal }}/articles
+        article_fragment_images_endpoint: {{ gateway_url_internal }}/articles/%s/fragments/image

--- a/pillar/environment-end2end-public.sls
+++ b/pillar/environment-end2end-public.sls
@@ -1,7 +1,39 @@
 elife:
     env: end2end
 
+{% set journal_cms_url = 'https://end2end--journal-cms.elifesciences.org' %}
+{% set journal_url = 'https://end2end--journal.elifesciences.org' %}
+{% set medium_url = 'http://end2end--medium.elife.internal' %}
+{% set search_url = 'http://end2end--search.elife.internal' %}
+{% set recommendations_url = 'http://end2end--recommendations.elife.internal' %}
+{% set gateway_url_public = 'https://end2end--cdn-gateway.elifesciences.org' %}
+{% set gateway_url_internal = 'http://end2end--gateway.elife.internal' %}
+{% set gateway_url_for_migration = 'https://prod--gateway.elifesciences.org' %}
+{% set lax_url = 'https://end2end--lax.elifesciences.org' %}
+{% set metrics_url = 'http://end2end--metrics.elife.internal' %}
+{% set profiles_url = 'http://end2end--profiles.elife.internal' %}
+{% set annotations_url = 'http://end2end--annotations.elife.internal' %}
+{% set digests_url = 'http://end2end--digests.elife.internal' %}
+{% set iiif_url = 'https://end2end--cdn-iiif.elifesciences.org' %}
+
 journal:
     feature_xpub: true
     # not existing yet:
     submit_url: https://end2end--xpub.elifesciences.org/login
+
+journal_cms:
+    aws:
+        queue: journal-cms--end2end
+        topic_template: arn:aws:sns:us-east-1:512686554592:bus-%s--end2end
+    journal:
+        base_uri: {{ journal_url }}
+    iiif:
+        base_uri: "{{ iiif_url }}/journal-cms/"
+        mount: iiif
+    api:
+        gateway: {{ gateway_url_internal }}
+        articles_endpoint_for_migration: {{ gateway_url_for_migration }}/articles/%s/versions
+        articles_endpoint: {{ gateway_url_internal }}/articles/%s/versions
+        metrics_endpoint: {{ gateway_url_internal }}/metrics/article/%s/%s
+        all_articles_endpoint: {{ gateway_url_internal }}/articles
+        article_fragment_images_endpoint: {{ gateway_url_internal }}/articles/%s/fragments/image

--- a/pillar/environment-prod-public.sls
+++ b/pillar/environment-prod-public.sls
@@ -1,6 +1,22 @@
 elife:
     env: prod
 
+{% set journal_url = 'https://elifesciences.org' %}
+{% set journal_preview_url = 'https://preview--journal.elifesciences.org' %}
+{% set journal_cms_url = 'https://prod--journal-cms.elifesciences.org' %}
+{% set medium_url = 'http://prod--medium.elife.internal' %}
+{% set search_url = 'http://prod--search.elife.internal' %}
+{% set recommendations_url = 'http://prod--recommendations.elife.internal' %}
+{% set lax_url = 'https://prod--lax.elifesciences.org' %}
+{% set gateway_url_public = 'https://api.elifesciences.org' %}
+{% set gateway_url_internal = 'http://prod--gateway.elife.internal' %}
+{% set gateway_url_for_migration = 'https://prod--gateway.elifesciences.org' %}
+{% set metrics_url = 'http://prod--metrics.elife.internal' %}
+{% set profiles_url = 'http://prod--profiles.elife.internal' %}
+{% set annotations_url = 'http://prod--annotations.elife.internal' %}
+{% set digests_url = 'http://prod--digests.elife.internal' %}
+{% set iiif_url = 'https://iiif.elifesciences.org' %}
+
 elife_xpub:
     api:
         endpoint: https://xpub.elifesciences.org
@@ -18,3 +34,21 @@ journal:
     feature_xpub: false
     submit_url: http://submit.elifesciences.org/
     #submit_url: https://xpub.elifesciences.org/login
+
+journal_cms:
+    aws:
+        queue: journal-cms--prod
+        topic_template: arn:aws:sns:us-east-1:512686554592:bus-%s--prod
+    journal:
+        base_uri: {{ journal_url }}
+        preview_uri: {{ journal_preview_url }}
+    iiif:
+        base_uri: "{{ iiif_url }}/journal-cms/"
+        mount: iiif
+    api:
+        gateway: {{ gateway_url_internal }}
+        articles_endpoint_for_migration: {{ gateway_url_for_migration }}/articles/%s/versions
+        articles_endpoint: {{ gateway_url_internal }}/articles/%s/versions
+        metrics_endpoint: {{ gateway_url_internal }}/metrics/article/%s/%s
+        all_articles_endpoint: {{ gateway_url_internal }}/articles
+        article_fragment_images_endpoint: {{ gateway_url_internal }}/articles/%s/fragments/image

--- a/pillar/journal-cms-public.sls
+++ b/pillar/journal-cms-public.sls
@@ -1,0 +1,57 @@
+journal_cms:
+    db:
+        name: elife_2_0
+        # user: 
+        # password: 
+
+    logs:
+        file_path: private://monolog/
+
+    files:
+        private_path: ./../private
+
+    journal:
+        base_uri: null
+        preview_uri: null
+
+    aws:
+        # access_key_id: 
+        # secret_access_key: 
+        region: us-east-1
+        queue: journal-cms--ci
+        endpoint: null
+        topic_template: arn:aws:sns:us-east-1:512686554592:bus-%s--ci
+
+    iiif:
+        base_uri: null
+        mount: iiif
+
+    api:
+        gateway: null
+        articles_endpoint_for_migration: null
+        articles_endpoint: null
+        metrics_endpoint: null
+        all_articles_endpoint: null
+        article_fragment_images_endpoint: null
+        # auth_unpublished: 
+
+    users:
+        alfred:
+            email: alfred@elifesciences.org
+            # password: 
+            role: administrator
+
+    # backup to be restored on testing instances (end2end only)
+    restore:
+        files: journal-cms/201705/20170522_prod--journal-cms.elifesciences.org_230509-archive-b47198f6.tar.gz
+        db: journal-cms/201705/20170522_prod--journal-cms.elifesciences.org_230506-elife_2_0-mysql.gz
+
+api_dummy:
+    standalone: False
+    pinned_revision_file: /srv/journal-cms/api-dummy.sha1
+
+elife:
+    php:
+        memory_limit: 128M
+        upload_max_filesize: 32M
+        post_max_size: 32M


### PR DESCRIPTION
Once in place, this will be editable here rather than from `builder-private`.

Commented out values are secrets, that will still reside in `builder-private`.

Goal is to make configuration https://github.com/elifesciences/journal-cms-formula/pull/47 simpler, and visible to all the team.