### PR TITLE
Add status checks to journal PR stacks

### DIFF
--- a/pillar/journal-pr-public.sls
+++ b/pillar/journal-pr-public.sls
@@ -6,9 +6,9 @@ journal:
     api_url_public: https://api.elifesciences.org
     status_checks:
         Annotations: ping/annotations
+        Digests: ping/digests
         Journal CMS: ping/journal-cms
         Lax: ping/lax
-        Medium: ping/medium
         Metrics: ping/metrics
         Profiles: ping/profiles
         Recommendations: ping/recommendations

--- a/pillar/journal-pr-public.sls
+++ b/pillar/journal-pr-public.sls
@@ -4,3 +4,12 @@ elife:
 journal:
     api_url: http://prod--gateway.elife.internal
     api_url_public: https://api.elifesciences.org
+    status_checks:
+        Annotations: ping/annotations
+        Journal CMS: ping/journal-cms
+        Lax: ping/lax
+        Medium: ping/medium
+        Metrics: ping/metrics
+        Profiles: ping/profiles
+        Recommendations: ping/recommendations
+        Search: ping/search


### PR DESCRIPTION
For https://github.com/elifesciences/journal-formula/pull/84

These apply both to journal and journal-formula PRs, although it happened by chance.

Will also soon need to be updated to transition from `medium` to `digests`.