### PR TITLE
Add SFTP configuration for elife-xpub--end2end

### DIFF
--- a/pillar/elife-xpub-end2end-public.sls
+++ b/pillar/elife-xpub-end2end-public.sls
@@ -1,0 +1,5 @@
+elife:
+    sidecars:
+        containers:
+            sftp:
+                enabled: true

--- a/pillar/elife-xpub-public.sls
+++ b/pillar/elife-xpub-public.sls
@@ -40,3 +40,15 @@ elife:
         # access_key_id:
         # secret_access_key:
         region: us-east-1
+    # only used in testing environments
+    sidecars:
+        containers:
+            sftp:
+                name: sftp
+                image: elifesciences/sftp
+                tag: 20190110
+                command: ejpdummy:ejpdummy:::meca
+                ports:
+                    # SSH/SFTP
+                    - "2222:22"
+                enabled: true

--- a/pillar/elife-xpub-public.sls
+++ b/pillar/elife-xpub-public.sls
@@ -51,4 +51,4 @@ elife:
                 ports:
                     # SSH/SFTP
                     - "2222:22"
-                enabled: true
+                enabled: false

--- a/pillar/environment-end2end-public.sls
+++ b/pillar/environment-end2end-public.sls
@@ -21,6 +21,15 @@ elife_xpub:
         endpoint: https://end2end--xpub.elifesciences.org
     pubsweet:
         base_url: https://end2end--xpub.elifesciences.org
+    meca:
+        sftp:
+            connection:
+                host: end2end--xpub--1.elife.internal
+                port: 21
+                # fake FTP server credentials
+                # username:
+                # password:
+            remote_path: 'files/'
     s3:
         bucket: end2end-elife-xpub
     deployment_target: end2end

--- a/pillar/environment-end2end-public.sls
+++ b/pillar/environment-end2end-public.sls
@@ -25,10 +25,11 @@ elife_xpub:
         sftp:
             connection:
                 host: end2end--xpub--1.elife.internal
+                port: 2222
                 # fake FTP server credentials
-                # username:
-                # password:
-            remote_path: 'files/'
+                username: ejpdummy
+                password: ejpdummy
+            remote_path: 'meca/'
     s3:
         bucket: end2end-elife-xpub
     deployment_target: end2end

--- a/pillar/environment-end2end-public.sls
+++ b/pillar/environment-end2end-public.sls
@@ -25,7 +25,6 @@ elife_xpub:
         sftp:
             connection:
                 host: end2end--xpub--1.elife.internal
-                port: 21
                 # fake FTP server credentials
                 # username:
                 # password:


### PR DESCRIPTION
A server will be running on the first node, where both servers will be able to upload files. These files can then be checked by end2end tests.