### PR TITLE
Prune xpub images not used for 1 day

### DIFF
--- a/pillar/elife-xpub-public.sls
+++ b/pillar/elife-xpub-public.sls
@@ -40,6 +40,8 @@ elife:
         # access_key_id:
         # secret_access_key:
         region: us-east-1
+    docker:
+        prune_days: 1
     # only used in testing environments
     sidecars:
         containers:


### PR DESCRIPTION
https://alfred.elifesciences.org/job/test-elife-xpub/618/consoleFull faileds because of 96% of inodes being in use on the Docker partition.

The formula currently [cleans everything not used in the last 3 days](https://github.com/elifesciences/elife-xpub-formula/blob/7b5d328b92d44422f69d5457af2d7876ef7a33e9/salt/elife-xpub/init.sls#L164-L168) but this configures the standard pruning from `builder-base-formula` to 1 day.

Hence we could then remove `docker-prune-last-days` from the `elife-xpub-formula` and just use the standard one, aggressively set to 1 day.