### PR TITLE
Add configuration for RDS infobars in journal

### DIFF
--- a/pillar/journal-public.sls
+++ b/pillar/journal-public.sls
@@ -1,3 +1,5 @@
 journal:
-     submit_url: https://submit.elifesciences.org/
-     feature_xpub: false
+    rds_articles:
+        30274: https://repro.elifesciences.org/example.html
+    submit_url: https://submit.elifesciences.org/
+    feature_xpub: false

--- a/pillar/journal-public.sls
+++ b/pillar/journal-public.sls
@@ -1,5 +1,5 @@
 journal:
     rds_articles:
-        30274: https://repro.elifesciences.org/example.html
+        '30274': https://repro.elifesciences.org/example.html
     submit_url: https://submit.elifesciences.org/
     feature_xpub: false


### PR DESCRIPTION
For https://github.com/elifesciences/issues/issues/4525

It doesn't seem harmful to configure this for all environments, last thing we want is for everything to pass in staging and then have a application bootstrap problem in `prod` when reading the config.

Note this file doesn't contain all configurations yet: some are still in [`builder-private`](https://github.com/elifesciences/builder-private).