### PR TITLE
Switch environment of master-server to prod

### DIFF
--- a/pillar/top.sls
+++ b/pillar/top.sls
@@ -8,6 +8,7 @@ base:
 
     'master-server--*':
         - master-server
+        - environment-prod-public # exception to the rule. keep last
         - environment-prod # exception to the rule. keep last
 
     'api-gateway--*':


### PR DESCRIPTION
Found out during https://github.com/elifesciences/issues/issues/4406

Shouldn't be a big change, but `pillar.elife.env` was evaluating to `ci`

/cc @lsh-0