### PR TITLE
Revert "change submit button to go to eJP"

### DIFF
--- a/pillar/environment-prod-public.sls
+++ b/pillar/environment-prod-public.sls
@@ -46,7 +46,7 @@ elife_xpub:
 
 journal:
     feature_xpub: true
-    submit_url: https://submit.elifesciences.org/
+    submit_url: https://reviewer.elifesciences.org/login
 
 journal_cms:
     aws:


### PR DESCRIPTION
Reverts elifesciences/builder-configuration#33

xpub should be ready in production again so turn the user filter back on.