### PR TITLE
Feature: adds newrelic-python to elife-dashboard

### DIFF
--- a/salt/top.sls
+++ b/salt/top.sls
@@ -38,6 +38,7 @@ base:
         - elife.python3
         - elife.postgresql
         - elife.nginx
+        - elife.newrelic-python
         - elife.uwsgi
         - elife.no-more-daemon
         - elife-dashboard


### PR DESCRIPTION
looking at `newrelic-python` it only has support for one application at a time, elife-article-scheduler might miss out