### PR TITLE
peerscout, upgrades nodejs6 to nodejs8

### DIFF
--- a/salt/top.sls
+++ b/salt/top.sls
@@ -456,7 +456,7 @@ base:
 
     'peerscout--*':
         - elife.nginx
-        - elife.nodejs6
+        - elife.nodejs8
         - elife.python3
         - elife.postgresql
         - elife.aws-cli


### PR DESCRIPTION
depends on either https://github.com/elifesciences/peerscout-formula/pull/32 or https://github.com/elifesciences/peerscout-formula/pull/30