### PR TITLE
Feature: search, cleans up the entries for the search project

### DIFF
--- a/salt/top.sls
+++ b/salt/top.sls
@@ -352,22 +352,7 @@ base:
     'medium--ci--*':
         - elife.proofreader-php
 
-    'search--*--1':
-        - elife.php7
-        - elife.composer
-        - elife.nginx
-        - elife.nginx-php7
-        - elife.postgresql
-        - elife.gearman
-        - elife.newrelic-php
-        - elife.aws-credentials
-        - elife.aws-cli
-        - elife.java8
-        - search.elasticsearch
-        - search.gearman-persistence
-        - search
-
-    # follower nodes
+    # 'follower' because it may not have elasticsearch installed
     'search--*':
         - elife.php7
         - elife.composer
@@ -377,6 +362,15 @@ base:
         - elife.aws-credentials
         - elife.aws-cli
         - search
+
+    # 'leader' because it has elasticsearch installed
+    'search--*--1':
+        - elife.postgresql
+        - elife.gearman
+        - elife.newrelic-php
+        - elife.java8
+        - search.elasticsearch
+        - search.gearman-persistence
 
     'search--ci--*':
         - api-dummy

--- a/salt/top.sls
+++ b/salt/top.sls
@@ -372,7 +372,7 @@ base:
         - search.elasticsearch
         - search.gearman-persistence
 
-    'search--ci--*':
+    'search--* and not search--end2end--* and not search--continuumtest--* and not search--prod--*':
         - api-dummy
         - search.api-dummy
         - elife.proofreader-php


### PR DESCRIPTION
* removes some duplicate states between 'search--*' and 'search--*--1'
* converts 'search--ci--*' to 'search--* (except prod/end2end/continuumtest/...)'. this follows the same pattern as the `digests` entry.

