### PR TITLE
Fix: search, switch from java8 to openjdk8

### DIFF
--- a/salt/top.sls
+++ b/salt/top.sls
@@ -368,7 +368,7 @@ base:
         - elife.postgresql
         - elife.gearman
         - elife.newrelic-php
-        - elife.java8
+        - elife.openjdk8
         - search.elasticsearch
         - search.gearman-persistence
 


### PR DESCRIPTION
depends on: https://github.com/elifesciences/builder-base-formula/pull/230