### PR TITLE
Feature: add peter back in to 'all projects' ssh access

### DIFF
--- a/pillar/elife-public.sls
+++ b/pillar/elife-public.sls
@@ -52,6 +52,7 @@ elife:
                 - luke_desktop
                 - giorgio
                 - chris
+                - peter
 
             # per-user, per-project access
             containers:
@@ -60,10 +61,8 @@ elife:
                 - daniel_inspiron
                 - daniel_xps
                 - nlisgo
-                - peter
             elife-xpub:
                 - alfred
-                - peter
                 - daniel
                 - daniel_inspiron
                 - daniel_xps
@@ -90,7 +89,6 @@ elife:
             profiles:
                 - giancarlo
             bastion:
-                - peter
                 - david
                 - daniel
                 - daniel_inspiron
@@ -107,9 +105,8 @@ elife:
         # removes keys. happens *after* allowed
         denied:
             # per-user denied access to all instances
-            all: # []
+            all:
                 - seanwiseman
-            # don't delete! leave commented as an example
             personalised-covers:
                 - scott
             bastion:


### PR DESCRIPTION
@diversemix , why did you give yourself ssh access to all project instances? what was your usecase?

because you added yourself to all projects, all projects that were able to complete highstate now have your pubkey in them. If you legitimately need access to all projects then this isn't a problem and this PR can be merged. If you were just trying to access a particular project or set of projects, we'll add you to them as necessary.

please open a PR in future and get review/approval first.