### PR TITLE
elife-alfred, move swap location to /ext/

### DIFF
--- a/pillar/elife-alfred-public.sls
+++ b/pillar/elife-alfred-public.sls
@@ -9,6 +9,8 @@ alfred:
         #secret_id: 
 
 elife:
+    swap:
+        path: /ext/swap.1
     helm:
         username: jenkins
     kubectl:


### PR DESCRIPTION
can be merged safely but won't take effect until swapoff + highstate

may need to remove old `/var/swap.1` file afterwards, not sure