### PR TITLE
Add pillar.data_pipeline.bigquery_views.materialize_arguments

### DIFF
--- a/pillar/data-pipeline-public.sls
+++ b/pillar/data-pipeline-public.sls
@@ -1,3 +1,34 @@
 data_pipeline:
+    nifi:
+        aws_access_name: data-pipeline
+        # aws_access_key:
+        # aws_secret_access_key:
+
+        # keystore_password:
+        # key_password:
+
+        oidc: {}
+            # client_id:
+            # client_secret:
+
+        sensitive_props: {}
+            # key:
+            # algorithm:
+            # provider:
+
+    nifi_registry: {}
+        # keystore_password:
+        # key_password:
+
     bigquery_views:
         revision: latest
+        materialize_arguments: ''
+
+elife:
+    swap:
+        path: /ext/swap.1
+
+    web_users:
+        nifi-registry-: {} # trailing hyphen not a typo
+            # username:
+            # password:

--- a/pillar/data-pipeline-public.sls
+++ b/pillar/data-pipeline-public.sls
@@ -22,7 +22,7 @@ data_pipeline:
 
     bigquery_views:
         revision: latest
-        materialize_arguments: ''
+        materialize_arguments: '--disable-view-name-mapping'
 
 elife:
     swap:

--- a/pillar/environment-prod-public.sls
+++ b/pillar/environment-prod-public.sls
@@ -96,3 +96,7 @@ journal_cms:
 lax:
     glencoe:
         cache_requests: False
+
+data_pipeline:
+    bigquery_views:
+        materialize_arguments: '--disable-view-name-mapping'

--- a/pillar/environment-prod-public.sls
+++ b/pillar/environment-prod-public.sls
@@ -99,4 +99,4 @@ lax:
 
 data_pipeline:
     bigquery_views:
-        materialize_arguments: '--disable-view-name-mapping'
+        materialize_arguments: ''


### PR DESCRIPTION
Taking the opportunity to also document some credentials that are invisibly kept in `builder-private` and will appear in pillars.