### PR TITLE
mysql, removes all mention of mysql57 in top file

### DIFF
--- a/salt/top.sls
+++ b/salt/top.sls
@@ -151,7 +151,8 @@ base:
         - elife.composer
         - elife.nginx
         - elife.nginx-php7
-        - elife.mysql57
+        - elife.mysql-client
+        - elife.mysql-server
         - elife.redis-server
         - elife.newrelic-php
         - elife.aws-cli
@@ -238,7 +239,8 @@ base:
         - elife.mercurial
         - elife.aws-cli
         - elife.external-volume
-        - elife.mysql57
+        - elife.mysql-client
+        - elife.mysql-server
         - elife.postgresql
         - elife.jenkins-node
         - elife.jenkins-scripts


### PR DESCRIPTION
`mysql57.sls` since the upgrade to 16.04+ has just been a reference to two other state files, `mysql-client.sls` and `mysql-server.sls`

this replaces references to this file in the state topfile with direct references to mysql-client and mysql-server (like all the other projects are using).