### PR TITLE
Remove obsolete python3.sls in favour of python.sls

### DIFF
--- a/salt/top.sls
+++ b/salt/top.sls
@@ -35,7 +35,6 @@ base:
         - api-gateway
 
     'elife-dashboard--*':
-        - elife.python
         - elife.postgresql-11
         - elife.nginx
         - elife.newrelic-python
@@ -93,7 +92,6 @@ base:
         - elife-bot.cron
 
     'lax--*':
-        - elife.python
         - elife.nginx
         - elife.uwsgi
         - elife.postgresql-11
@@ -192,7 +190,6 @@ base:
 
     'elife-metrics--*':
         - elife.no-more-daemon
-        - elife.python
         - elife.nginx
         - elife.uwsgi
         - elife.postgresql-11
@@ -218,7 +215,6 @@ base:
         - elife-alfred
         - elife-alfred.postfix
         - elife.hub
-        - elife.python
         - elife.kubectl
         - elife.helm
 
@@ -227,7 +223,6 @@ base:
         - elife.php7
         - elife.composer
         - elife.nodejs6
-        - elife.python
         - elife.mercurial
         - elife.aws-cli
         - elife.external-volume
@@ -368,7 +363,6 @@ base:
 
     'observer--*':
         - elife.uwsgi
-        - elife.python
         - elife.java8
         - elife.nginx
         - elife.postgresql-11
@@ -435,7 +429,6 @@ base:
         - elife.postgresql-container
 
     'profiles--*':
-        - elife.python
         - elife.uwsgi
         - elife.nginx
         - elife.aws-credentials

--- a/salt/top.sls
+++ b/salt/top.sls
@@ -35,7 +35,7 @@ base:
         - api-gateway
 
     'elife-dashboard--*':
-        - elife.python3
+        - elife.python
         - elife.postgresql-11
         - elife.nginx
         - elife.newrelic-python
@@ -93,7 +93,7 @@ base:
         - elife-bot.cron
 
     'lax--*':
-        - elife.python3
+        - elife.python
         - elife.nginx
         - elife.uwsgi
         - elife.postgresql-11
@@ -192,7 +192,7 @@ base:
 
     'elife-metrics--*':
         - elife.no-more-daemon
-        - elife.python3
+        - elife.python
         - elife.nginx
         - elife.uwsgi
         - elife.postgresql-11
@@ -218,7 +218,7 @@ base:
         - elife-alfred
         - elife-alfred.postfix
         - elife.hub
-        - elife.python3
+        - elife.python
         - elife.kubectl
         - elife.helm
 
@@ -227,7 +227,7 @@ base:
         - elife.php7
         - elife.composer
         - elife.nodejs6
-        - elife.python3
+        - elife.python
         - elife.mercurial
         - elife.aws-cli
         - elife.external-volume
@@ -368,7 +368,7 @@ base:
 
     'observer--*':
         - elife.uwsgi
-        - elife.python3
+        - elife.python
         - elife.java8
         - elife.nginx
         - elife.postgresql-11
@@ -435,7 +435,7 @@ base:
         - elife.postgresql-container
 
     'profiles--*':
-        - elife.python3
+        - elife.python
         - elife.uwsgi
         - elife.nginx
         - elife.aws-credentials


### PR DESCRIPTION
* `python.sls` is included in the `init.sls` which is included for [*all* projects](https://github.com/elifesciences/builder-base-formula/blob/master/elife/init.sls#L6)