### PR TITLE
Remove deprecated rds_articles

### DIFF
--- a/pillar/journal-public.sls
+++ b/pillar/journal-public.sls
@@ -68,9 +68,6 @@ journal:
 
     example_rds_articles:
         '30274': https://repro.elifesciences.org/example.html
-    # deprecated, remove to make room for https://github.com/elifesciences/journal/pull/1220
-    rds_articles:
-        '30274': https://repro.elifesciences.org/example.html
     dismissible_info_bars:
         aging:
             id: aging-special-issue


### PR DESCRIPTION
Depends on https://github.com/elifesciences/journal/pull/1223 being applied everywhere and on https://github.com/elifesciences/journal-formula/pull/110 for removal from the formula.