### PR TITLE
fixes url of search.elasticsearch.servers in continuumtest env

### DIFF
--- a/pillar/environment-continuumtest-public.sls
+++ b/pillar/environment-continuumtest-public.sls
@@ -89,7 +89,7 @@ search:
         requests_batch: 20
 
     elasticsearch:
-        servers: http://end2end--search--1.elife.internal:9200
+        servers: http://continuumtest--search.elife.internal:9200
         logging: true
 
     rate_limit_minimum_page: 21


### PR DESCRIPTION
this should get highstate working on search--continuumtest again

if there was a special reason the path was pointed at end2end rather than continuumtest then we need a comment explaining why.