### PR TITLE
Lower number of search workers

### DIFF
--- a/pillar/search-public.sls
+++ b/pillar/search-public.sls
@@ -40,10 +40,10 @@ elife:
         services:
             search-gearman-worker:
                 service_template: search-gearman-worker-service
-                num_processes: 3
+                num_processes: 1
             search-queue-watch:
                 service_template: search-queue-watch-service
-                num_processes: 3
+                num_processes: 1
 
 api_dummy:
     standalone: False


### PR DESCRIPTION
Especially during reindexing, it seems these processes are CPU-bound. `search` nodes have 2 CPUs so in addition to all the daemons that are running these 2 processes should saturate them already.