### PR TITLE
java cleanup

### DIFF
--- a/salt/top.sls
+++ b/salt/top.sls
@@ -298,7 +298,7 @@ base:
         - elife.postgresql
         - elife.gearman
         - elife.newrelic-php
-        - elife.openjdk8
+        - elife.java8
         - search.elasticsearch
         - search.gearman-persistence
         - search.leader


### PR DESCRIPTION
replaces references of openjdk8 with java8