### PR TITLE
Revert "search, bumps gearman workers to 3"

### DIFF
--- a/pillar/search-public.sls
+++ b/pillar/search-public.sls
@@ -40,7 +40,7 @@ elife:
         services:
             search-gearman-worker:
                 service_template: search-gearman-worker-service
-                num_processes: 3
+                num_processes: 1
             search-queue-watch:
                 service_template: search-queue-watch-service
                 num_processes: 1


### PR DESCRIPTION
Reverts elifesciences/builder-configuration#143, which reverted https://github.com/elifesciences/builder-configuration/pull/122.

Elasticsearch appears to be saturated at the moment and isn't indexing content.