### PR TITLE
Add new medicine msa redirect to production journal

### DIFF
--- a/pillar/environment-prod-public.sls
+++ b/pillar/environment-prod-public.sls
@@ -73,6 +73,10 @@ journal:
     cache_control: public, max-age={{ 60 * 30 }}, s-maxage={{ 60 * 62 }}, stale-while-revalidate={{ 60 * 60 * 12 }}, stale-if-error={{ 60 * 60 * 24 }}
     feature_xpub: true
     submit_url: https://reviewer.elifesciences.org/login
+    subject_rewrites:
+        - from_id: medicine
+          to_id: human-biology-medicine
+          to_name: Human Biology and Medicine
 
 journal_cms:
     aws:


### PR DESCRIPTION
Since https://github.com/elifesciences/builder-configuration/pull/146 has been merged in and deployed to continuumtest I can confirm that the redirect from https://continuumtest--journal.elifesciences.org/subjects/medicine to https://continuumtest--journal.elifesciences.org/subjects/human-biology-medicine is working.

This PR sets the same configuration for the production instance of journal.