### PR TITLE
iiif, move deviation checker out of main iiif ns

### DIFF
--- a/salt/top.sls
+++ b/salt/top.sls
@@ -387,10 +387,12 @@ base:
         - elife.external-volume
         - elife.newrelic-python
         - elife.docker
-        #- iiif.loris # 2020-03: disabled in favour of init.sls and containers
         - iiif.loris-removal
         - iiif
         - iiif.loris-maintenance
+
+    'iiif--devchk*':
+        - elife.java8
         - iiif.deviation-checker
 
     'redirects--*':


### PR DESCRIPTION
* moved deviation tester under own heading
* adds new requisite 'java8'