### PR TITLE
journal, robots.txt, blocks ris and bib file types.

### DIFF
--- a/pillar/journal-public.sls
+++ b/pillar/journal-public.sls
@@ -19,16 +19,20 @@ journal:
     # - https://developers.google.com/search/reference/robots_txt#url-matching-based-on-path-values
     robots:
         - |
-            User-Agent: *
+            User-agent: *
             Disallow: $robots_disallow
             Disallow: /download/
-        - | 
+        - |
+            User-agent: Googlebot
+            Disallow: /*.ris
+            Disallow: /*.bib
+        - |
             User-agent: Amazonbot
             Disallow: /search
-        - | 
+        - |
             User-agent: turnitinbot
             Disallow: /search
-        - | 
+        - |
             User-agent: bingbot
             Disallow: /search
 

--- a/pillar/journal-public.sls
+++ b/pillar/journal-public.sls
@@ -22,6 +22,8 @@ journal:
             User-agent: *
             Disallow: $robots_disallow
             Disallow: /download/
+        # probably unnecessary:
+        # https://github.com/elifesciences/issues/issues/5860
         - |
             User-agent: Googlebot
             Disallow: /*.ris


### PR DESCRIPTION
these files are being reported as 'soft 404s' and, perhaps, maybe, affecting our search ranking.