### PR TITLE
Introduce MSA rewrite from human-biology-medicine to medicine on continuumtest

### DIFF
--- a/pillar/environment-continuumtest-public.sls
+++ b/pillar/environment-continuumtest-public.sls
@@ -63,9 +63,9 @@ journal:
         - .*\.elifesciences.org$
 
     subject_rewrites:
-        - from_id: medicine
-          to_id: human-biology-medicine
-          to_name: Human Biology and Medicine
+        - from_id: human-biology-medicine
+          to_id: medicine
+          to_name: Medicine
 
 journal_cms:
     aws:


### PR DESCRIPTION
This will impact continuumtest only and will confirm that the approach for reassigning content to `medicine` from `human-biology-medicine` will work on production.