### PR TITLE
Revert "Enable rds feature in production instance of seacrh and journal"

### DIFF
--- a/pillar/journal-public.sls
+++ b/pillar/journal-public.sls
@@ -74,7 +74,7 @@ journal:
 
     subject_rewrites: []
 
-    feature_rds: true
+    feature_rds: false
     {% import_yaml "rds-articles.yaml" as rds_articles %}
     rds_articles: {{ rds_articles|yaml }}
 

--- a/pillar/search-public.sls
+++ b/pillar/search-public.sls
@@ -24,7 +24,7 @@ search:
     ttl: 300
     rate_limit_minimum_page: 2
 
-    feature_rds: true
+    feature_rds: false
     {% import_yaml "rds-articles.yaml" as rds_articles %}
     rds_articles: {{ rds_articles|yaml }}
 


### PR DESCRIPTION
This reverts commit 1373432aa7d77761c42f222f5cb0a5ecba9b972a.