### PR TITLE
Remove rds feature configuration

### DIFF
--- a/pillar/environment-continuumtest-public.sls
+++ b/pillar/environment-continuumtest-public.sls
@@ -55,8 +55,6 @@ journal:
     # turned on temporarily to reproduce production environment in Fastly shield debugging
     cache_control: public, max-age={{ 60 * 30 }}, s-maxage={{ 60 * 62 }}, stale-while-revalidate={{ 60 * 60 * 12 }}, stale-if-error={{ 60 * 60 * 24 }}
 
-    feature_rds: true
-
     feature_xpub: true
     submit_url: https://libero-reviewer--staging.elifesciences.org/login
     submit_url_redirects:
@@ -95,5 +93,3 @@ search:
         logging: true
 
     rate_limit_minimum_page: 21
-
-    feature_rds: true

--- a/pillar/environment-preview-public.sls
+++ b/pillar/environment-preview-public.sls
@@ -18,8 +18,6 @@ journal:
         Recommendations: ping/recommendations
         Search: ping/search
 
-    feature_rds: true
-
     # web_users: # see builder-private
     feature_xpub: false
     submit_url: https://reviewer.elifesciences.org/login

--- a/pillar/journal-public.sls
+++ b/pillar/journal-public.sls
@@ -74,7 +74,6 @@ journal:
 
     subject_rewrites: []
 
-    feature_rds: true
     {% import_yaml "rds-articles.yaml" as rds_articles %}
     rds_articles: {{ rds_articles|yaml }}
 

--- a/pillar/search-public.sls
+++ b/pillar/search-public.sls
@@ -24,7 +24,6 @@ search:
     ttl: 300
     rate_limit_minimum_page: 2
 
-    feature_rds: true
     {% import_yaml "rds-articles.yaml" as rds_articles %}
     rds_articles: {{ rds_articles|yaml }}
 


### PR DESCRIPTION
Now that the RDS feature code has been removed from journal we can remove the configuration to enable/disable it in different environments.

See :https://github.com/elifesciences/journal/pull/1321