### PR TITLE
Add article_fragments_endpoint setting

### DIFF
--- a/pillar/environment-continuumtest-public.sls
+++ b/pillar/environment-continuumtest-public.sls
@@ -77,6 +77,7 @@ journal_cms:
         metrics_endpoint: {{ gateway_url_internal }}/metrics/article/%s/%s
         all_articles_endpoint: {{ gateway_url_internal }}/articles
         all_digests_endpoint: {{ gateway_url_internal }}/digests
+        article_fragments_endpoint: {{ gateway_url_internal }}/articles/%s/fragments
         article_fragment_images_endpoint: {{ gateway_url_internal }}/articles/%s/fragments/image
 
 lax:

--- a/pillar/environment-continuumtest-public.sls
+++ b/pillar/environment-continuumtest-public.sls
@@ -77,7 +77,7 @@ journal_cms:
         metrics_endpoint: {{ gateway_url_internal }}/metrics/article/%s/%s
         all_articles_endpoint: {{ gateway_url_internal }}/articles
         all_digests_endpoint: {{ gateway_url_internal }}/digests
-        article_fragments_endpoint: {{ gateway_url_internal }}/articles/%s/fragments
+        article_fragments_endpoint: {{ gateway_url_internal }}/articles/%s/fragments/%s
         article_fragment_images_endpoint: {{ gateway_url_internal }}/articles/%s/fragments/image
 
 lax:

--- a/pillar/environment-end2end-public.sls
+++ b/pillar/environment-end2end-public.sls
@@ -82,6 +82,7 @@ journal_cms:
         metrics_endpoint: {{ gateway_url_internal }}/metrics/article/%s/%s
         all_articles_endpoint: {{ gateway_url_internal }}/articles
         all_digests_endpoint: {{ gateway_url_internal }}/digests
+        article_fragments_endpoint: {{ gateway_url_internal }}/articles/%s/fragments
         article_fragment_images_endpoint: {{ gateway_url_internal }}/articles/%s/fragments/image
 
 lax:

--- a/pillar/environment-end2end-public.sls
+++ b/pillar/environment-end2end-public.sls
@@ -82,7 +82,7 @@ journal_cms:
         metrics_endpoint: {{ gateway_url_internal }}/metrics/article/%s/%s
         all_articles_endpoint: {{ gateway_url_internal }}/articles
         all_digests_endpoint: {{ gateway_url_internal }}/digests
-        article_fragments_endpoint: {{ gateway_url_internal }}/articles/%s/fragments
+        article_fragments_endpoint: {{ gateway_url_internal }}/articles/%s/fragments/%s
         article_fragment_images_endpoint: {{ gateway_url_internal }}/articles/%s/fragments/image
 
 lax:

--- a/pillar/environment-prod-public.sls
+++ b/pillar/environment-prod-public.sls
@@ -97,7 +97,7 @@ journal_cms:
         metrics_endpoint: {{ gateway_url_internal }}/metrics/article/%s/%s
         all_articles_endpoint: {{ gateway_url_internal }}/articles
         all_digests_endpoint: {{ gateway_url_internal }}/digests
-        article_fragments_endpoint: {{ gateway_url_internal }}/articles/%s/fragments
+        article_fragments_endpoint: {{ gateway_url_internal }}/articles/%s/fragments/%s
         article_fragment_images_endpoint: {{ gateway_url_internal }}/articles/%s/fragments/image
 
 lax:

--- a/pillar/environment-prod-public.sls
+++ b/pillar/environment-prod-public.sls
@@ -97,6 +97,7 @@ journal_cms:
         metrics_endpoint: {{ gateway_url_internal }}/metrics/article/%s/%s
         all_articles_endpoint: {{ gateway_url_internal }}/articles
         all_digests_endpoint: {{ gateway_url_internal }}/digests
+        article_fragments_endpoint: {{ gateway_url_internal }}/articles/%s/fragments
         article_fragment_images_endpoint: {{ gateway_url_internal }}/articles/%s/fragments/image
 
 lax:

--- a/pillar/journal-cms-public.sls
+++ b/pillar/journal-cms-public.sls
@@ -33,6 +33,7 @@ journal_cms:
         metrics_endpoint: null
         all_articles_endpoint: null
         all_digests_endpoint: null
+        article_fragments_endpoint: null
         article_fragment_images_endpoint: null
         # auth_unpublished: 
 


### PR DESCRIPTION
This is needed for: https://github.com/elifesciences/journal-cms/pull/679

This will need to merged in before: https://github.com/elifesciences/journal-cms-formula/pull/68

Both can be deployed at the same time. Once the Journal CMS PR is merged and deployed we can remove references to `article_fragment_images_endpoint` here and in `journal-cms-formula`.