### PR TITLE
Remove reference to article_fragment_images_endpoint

### DIFF
--- a/pillar/environment-continuumtest-public.sls
+++ b/pillar/environment-continuumtest-public.sls
@@ -78,7 +78,6 @@ journal_cms:
         all_articles_endpoint: {{ gateway_url_internal }}/articles
         all_digests_endpoint: {{ gateway_url_internal }}/digests
         article_fragments_endpoint: {{ gateway_url_internal }}/articles/%s/fragments/%s
-        article_fragment_images_endpoint: {{ gateway_url_internal }}/articles/%s/fragments/image
 
 lax:
     glencoe:

--- a/pillar/environment-end2end-public.sls
+++ b/pillar/environment-end2end-public.sls
@@ -83,7 +83,6 @@ journal_cms:
         all_articles_endpoint: {{ gateway_url_internal }}/articles
         all_digests_endpoint: {{ gateway_url_internal }}/digests
         article_fragments_endpoint: {{ gateway_url_internal }}/articles/%s/fragments/%s
-        article_fragment_images_endpoint: {{ gateway_url_internal }}/articles/%s/fragments/image
 
 lax:
     glencoe:

--- a/pillar/environment-prod-public.sls
+++ b/pillar/environment-prod-public.sls
@@ -98,7 +98,6 @@ journal_cms:
         all_articles_endpoint: {{ gateway_url_internal }}/articles
         all_digests_endpoint: {{ gateway_url_internal }}/digests
         article_fragments_endpoint: {{ gateway_url_internal }}/articles/%s/fragments/%s
-        article_fragment_images_endpoint: {{ gateway_url_internal }}/articles/%s/fragments/image
 
 lax:
     glencoe:

--- a/pillar/journal-cms-public.sls
+++ b/pillar/journal-cms-public.sls
@@ -34,7 +34,6 @@ journal_cms:
         all_articles_endpoint: null
         all_digests_endpoint: null
         article_fragments_endpoint: null
-        article_fragment_images_endpoint: null
         # auth_unpublished: 
 
     users:


### PR DESCRIPTION
This should be merged in after: https://github.com/elifesciences/journal-cms-formula/pull/69

This is related to: https://github.com/elifesciences/journal-cms/pull/680