### PR TITLE
Add reference to sitemap in robots.txt

### DIFF
--- a/pillar/journal-public.sls
+++ b/pillar/journal-public.sls
@@ -52,6 +52,8 @@ journal:
         - |
             User-agent: SemrushBot
             Disallow: /
+        - |
+            Sitemap: https://elifesciences.org/sitemap.xml
 
     redis_cache: null
     redis_sessions: null


### PR DESCRIPTION
Installing a sitemap has been suggested as the solution to some of our content not having been indexed on google scholar. I am keen to get this in before the holiday. In a couple of weeks we should be able to determine whether the doi content is listed in google scholar.