### PR TITLE
api-gateway, xpub removal

### DIFF
--- a/pillar/api-gateway-public.sls
+++ b/pillar/api-gateway-public.sls
@@ -205,7 +205,7 @@ api_gateway:
     consumers:
         # user: key
         anonymous: public
-        # elife-xpub: secretkey
+        # some-elife-app: secretkey
 
     groups:
         anonymous:
@@ -233,14 +233,12 @@ api_gateway:
         elife-bot:
             - edit-digests
             - view-unpublished-content
-        elife-xpub:
-            - view-restricted-people
-            - view-restricted-profiles
 
     # api consumers who once existed but should not exist any longer
     absent_consumers:
         - bottersnipe
         - website
+        - elife-xpub
 
     absent_groups:
         journal-cms-unpublished-content:
@@ -249,3 +247,6 @@ api_gateway:
             - admin
         alfred:
             - admin
+        elife-xpub:
+            - view-restricted-people
+            - view-restricted-profiles


### PR DESCRIPTION
* api-gateway, adds elife-xpub to absent-consumers and absent-groups

fyi @nlisgo @NuclearRedeye , this will allow [builds](https://github.com/elifesciences/api-gateway-formula/pull/26) to start passing and daily updates to be re-enabled on prod. They're all failing right now.