### PR TITLE
Api gateway xpub removal 3

### DIFF
--- a/pillar/api-gateway-public.sls
+++ b/pillar/api-gateway-public.sls
@@ -207,9 +207,8 @@ api_gateway:
         anonymous: public
         # some-elife-app: secretkey
         # removing a consumer is a two-step process. 
-        # 1. consumer must be present in order to remove from groups. 'key' isn't used to do this.
+        # 1. consumer must be present in order to be remove from groups. 'key' value isn't necessary
         # 2. consumer can be removed
-        elife-xpub: placeholder
 
     groups:
         anonymous:
@@ -242,7 +241,7 @@ api_gateway:
     absent_consumers:
         - bottersnipe
         - website
-        #- elife-xpub
+        - elife-xpub
 
     absent_groups:
         journal-cms-unpublished-content:

--- a/pillar/api-gateway-public.sls
+++ b/pillar/api-gateway-public.sls
@@ -207,7 +207,7 @@ api_gateway:
         anonymous: public
         # some-elife-app: secretkey
         # removing a consumer is a two-step process. 
-        # 1. consumer must be present in order to be remove from groups. 'key' value isn't necessary
+        # 1. consumer must be present in order to be removed from groups. consumer 'key' value isn't used.
         # 2. consumer can be removed
 
     groups:


### PR DESCRIPTION
Third time's the charm. Removes elife-xpub as a consumer. [Build](https://github.com/elifesciences/api-gateway-formula/pull/26) is green. Re-enabled daily system updates on prod ... also green.


cc @NuclearRedeye @nlisgo 