### PR TITLE
journal, adds seekport to list of bots to block.

### DIFF
--- a/pillar/journal-public.sls
+++ b/pillar/journal-public.sls
@@ -26,6 +26,7 @@ journal:
         - |
             User-agent: *
             Disallow: $robots_disallow
+            Disallow: /search
             Disallow: /download/
             Crawl-delay: 10
         # probably unnecessary:
@@ -62,16 +63,17 @@ journal:
             User-agent: SemrushBot
             Disallow: /
             Disallow: /download/
-        # paid-for SEO search engine
-        # consistently hundreds of requests an hour
         - |
             User-agent: MJ12bot
             Disallow: /
         - |
-            Sitemap: https://elifesciences.org/sitemap.xml
-        - |
             User-agent: trendkite-akashic-crawler
             Disallow: /
+        - |
+            User-agent: Seekport Crawler
+            Disallow: /
+        - |
+            Sitemap: https://elifesciences.org/sitemap.xml
 
     redis_cache: null
     redis_sessions: null

--- a/pillar/journal-public.sls
+++ b/pillar/journal-public.sls
@@ -73,6 +73,9 @@ journal:
             User-agent: Seekport Crawler
             Disallow: /
         - |
+            User-agent: Linespider
+            Disallow: /
+        - |
             Sitemap: https://elifesciences.org/sitemap.xml
 
     redis_cache: null


### PR DESCRIPTION
adds /search to list of disallowed paths for all bots without a mention.
this shouldn't affect Google as it has a specific entry without that rule.

fyi @NuclearRedeye 