### PR TITLE
search, adds elife.swapspace.

### DIFF
--- a/salt/top.sls
+++ b/salt/top.sls
@@ -294,6 +294,7 @@ base:
         - elife.newrelic-php
         - elife.java8
         - elife.docker
+        - elife.swapspace
         - search.elasticsearch
         - search.opensearch
         - search.gearman-persistence


### PR DESCRIPTION
a full reindex on search with OpenSearch uses just a bit too much memory for my liking.