### PR TITLE
eks.clusters, disables kubernetes-aws--test

### DIFF
--- a/pillar/elife-public.sls
+++ b/pillar/elife-public.sls
@@ -45,10 +45,11 @@ elife:
             #    enabled: True
 
     eks:
-        clusters:
-            kubernetes-aws--test:
-                region: us-east-1
-                role: arn:aws:iam::512686554592:role/kubernetes-aws--test--AmazonEKSUserRole
+        clusters: {}
+            # lsh@2022-02-18: disabled, kubernetes-aws--test has been deleted
+            #kubernetes-aws--test:
+            #    region: us-east-1
+            #    role: arn:aws:iam::512686554592:role/kubernetes-aws--test--AmazonEKSUserRole
 
     mockserver:
         expectations: {}


### PR DESCRIPTION
it broke a highstate today with:

```
----------
          ID: aws-eks-update-kube-config-kubernetes-aws--test
    Function: cmd.run
        Name: aws eks update-kubeconfig --name kubernetes-aws--test --role-arn arn:aws:iam::512686554592:role/kubernetes-aws--test--AmazonEKSUserRole
      Result: False
     Comment: Command "aws eks update-kubeconfig --name kubernetes-aws--test --role-arn arn:aws:iam::512686554592:role/kubernetes-aws--test--AmazonEKSUserRole" run
     Started: 21:17:31.601575
    Duration: 732.535 ms
     Changes:   
              ----------
              pid:
                  27332
              retcode:
                  255
              stderr:
                  
                  An error occurred (ResourceNotFoundException) when calling the DescribeCluster operation: No cluster found for name: kubernetes-aws--test.
              stdout:
```

the failing state is this one: https://github.com/elifesciences/builder-base-formula/blame/master/elife/kubectl.sls

introduced here: https://github.com/elifesciences/builder-base-formula/commit/86e8972102dd78b3334a0bc333e80e682c80eeff

@scottaubrey , from what I can tell of the documentation, this command ensures that `kubectl` has some configuration for interacting with the given cluster. `elife-alfred` (Jenkins) and the `containers` project  (for building containers) both use this state. I'm not sure how `containers` and that cluster were interacting, there isn't much [going on in there](https://github.com/elifesciences/containers-formula/blob/master/salt/containers/init.sls).

fyi @NuclearRedeye 