### PR TITLE
Configure empty about_url config, set to pubpub for continuumtest

### DIFF
--- a/pillar/environment-continuumtest-public.sls
+++ b/pillar/environment-continuumtest-public.sls
@@ -28,6 +28,7 @@ journal:
     #observer_url: http://continuumtest--observer.elife.internal
     # no trailing slashes. leave empty to prevent adding redirect rules.
     preprint_url: https://staging--epp.elifesciences.org
+    about_url: https://elife-container.pubpub.org
     default_host: continuumtest--cdn-journal.elifesciences.org
     cb_id: 0a5c50d8-fcf9-47b1-8f4f-1eaadb13941b
     oauth2_client_id: journal--continuumtest

--- a/pillar/journal-public.sls
+++ b/pillar/journal-public.sls
@@ -6,6 +6,7 @@ journal:
     observer_url: http://prod--observer.elife.internal
     # no trailing slashes. leave empty to prevent adding redirect rules.
     preprint_url:
+    about_url:
     default_host: null
 
     google_api_client:


### PR DESCRIPTION
Relates to https://github.com/elifesciences/enhanced-preprints-issues/issues/416

Setup the needed salt data for a reverse proxy of about pages