### PR TITLE
removes 'elife-ink'.

### DIFF
--- a/pillar/top.sls
+++ b/pillar/top.sls
@@ -125,9 +125,6 @@ base:
     'digests--*':
         - digests
 
-    'elife-ink--*':
-        - elife-ink
-
     'bioprotocol--*':
         - bioprotocol
 

--- a/salt/top.sls
+++ b/salt/top.sls
@@ -417,12 +417,6 @@ base:
         - elife.docker-databases
         - digests
 
-    'elife-ink--*':
-        - elife.nginx
-        - elife.docker-native
-        - elife-ink
-        - elife-ink.nginx
-
     'bastion--*':
         - elife.swapspace
         - bastion


### PR DESCRIPTION
project is archived and I've never seen an ec2 instance of it ever.