### PR TITLE
journal, fix for nginx inability to handle literal dollar signs.

### DIFF
--- a/pillar/journal-public.sls
+++ b/pillar/journal-public.sls
@@ -44,7 +44,7 @@ journal:
             User-agent: Googlebot
             Disallow: /*.ris
             Disallow: /*.bib
-            Allow: /search$
+            Allow: /search$dollar
             Disallow: /search?
             Disallow: /download/
 


### PR DESCRIPTION
depends on builder-base-formula adding '$dollar' variable to nginx config:
https://github.com/elifesciences/builder-base-formula/pull/406